### PR TITLE
プロンプトの調整、画像生成モデルの変更、キャラ削除機能の実装、キャラ一覧ページの調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@
 /config/credentials/environment_name.key
 
 /.env
+
+/public/uploads/characters

--- a/app/controllers/characters_controller.rb
+++ b/app/controllers/characters_controller.rb
@@ -71,6 +71,6 @@ class CharactersController < ApplicationController
   def destroy
     @character = Character.find(params[:id])
     @character.destroy!
-    redirect_to characters_path, notice: "キャラクターを削除しました。"
+    redirect_to user_characters_path(current_user), notice: "キャラクターを削除しました。"
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,5 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+import Rails from "@rails/ujs"
+Rails.start()

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -1,6 +1,8 @@
 class Character < ApplicationRecord
   mount_uploader :image, CharacterImageUploader
 
+  before_destroy :remove_image!
+
   belongs_to :user
   has_many :skills, dependent: :destroy
   has_many :battles_as_character_1, class_name: 'Battle', foreign_key: :character_1_id
@@ -13,4 +15,12 @@ class Character < ApplicationRecord
   validates :strength, presence: true
   validates :intelligence, presence: true
   # validates :image, presence: true
+
+  private
+
+  def remove_image!
+    image.remove! if image.present?
+  rescue => e
+    Rails.logger.error("Failed to remove image: #{e.message}")
+  end
 end

--- a/app/services/create_character_service.rb
+++ b/app/services/create_character_service.rb
@@ -11,12 +11,12 @@ class CreateCharacterService
       「#{description}」 
       上記のdescription_from_userに基づいて「#{type}」を考案し、name_of_character, description_of_character, appearance_of_character, HP, agility, strength, intelligence, name_of_skill_A, description_of_skill_A, name_of_skill_B, description_of_skill_B, name_of_skill_C, description_of_skill_CをJSON形式のみで返してください。 
       - これらはすべて必須項目です。
+      - 必ず、HP、agility、strength、intelligenceは数字、appearance_of_characterは英語、name_of_character、description_of_characterは日本語で書いてください。 
       - name_of_characterは、可能な限りひねった名前を考えてください。
-      - description_of_characterは100~200文字、appearance_of_characterは50~120文字、description_of_skillは10~50文字で書いてください。 
+      - description_of_characterは200~300文字、appearance_of_characterは100~200文字、description_of_skillは10~50文字で書いてください。 
       - description_of_characterは、description_from_userから判断して、弱そうなキャラクターの場合は弱そうな説明にし、強そうなキャラクターの場合は強そうな説明にしてください。
       - HP、agility、strength、intelligenceの合計値の最大値は600です。判断基準は、弱いキャラクターは合計値が300未満、強いキャラクターは合計値が301以上です。
       - description_of_characterに性別に関する記述が含まれている場合、appearance_of_characterでも性別がわかるようにしてください。
-      - HP、agility、strength、intelligenceはすべて数字、それ以外はすべて日本語の文章で書いてください。 
     PROMPT
 
     begin

--- a/app/services/dalle_service.rb
+++ b/app/services/dalle_service.rb
@@ -1,7 +1,7 @@
 class DalleService
   def self.generate_image(appearance)
     prompt = <<~PROMPT
-      あなたはプロのアーティストです。以下の特徴に基づいて、キャラクターの高品質なデジタルイラストを、アメコミ風のスタイルで描いてください：
+      You are a professional artist. Create a high-quality illustration of a character in a Nintendo-inspired style, including a vibrant background that complements the character's traits based on the description:
       #{appearance}
     PROMPT
     puts "DALL·E API Request: #{prompt}" # デバッグ出力
@@ -9,10 +9,7 @@ class DalleService
     response = client.images.generate(
       parameters: {
         prompt: prompt,
-        model: "dall-e-3",
-        size: "1024x1024",
-        quality: "standard",
-        n: 1
+        size: "256x256",
       }
     )
   

--- a/app/views/characters/index.html.erb
+++ b/app/views/characters/index.html.erb
@@ -1,26 +1,27 @@
-<div class="container mx-auto p-6">
+<div class="container mx-auto p-2 md:p-6">
   <!-- ページタイトル -->
   <h1 class="text-4xl font-bold text-center mb-8">キャラクター一覧</h1>
 
   <!-- キャラクター一覧 -->
-  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+  <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
     <% @characters.each do |character| %>
       <div class="card bg-base-100 shadow-md hover:shadow-lg transition-shadow">
         <!-- キャラクター画像 -->
-        <figure>
-          <%= image_tag(character.image.url, alt: character.name, class: "w-full h-48 object-cover rounded-t-lg") if character.image? %>
-        </figure>
+        <figure class="w-full h-48 object-cover rounded-t-lg overflow-hidden">
+          <%= link_to character_path(character), class: "block w-full h-full" do %>
+            <%= image_tag(character.image? ? character.image.url : "https://placehold.jp/150x150.png", alt: character.name, class: "w-full h-full object-cover") %>
+          <% end %>
+        </figure> 
 
         <!-- キャラクター情報 -->
         <div class="p-4">
           <h2 class="text-xl font-semibold mb-2"><%= character.name %></h2>
-          <p class="text-sm text-gray-600 mb-4"><%= truncate(character.description, length: 100) %></p>
+          <p class="text-xs md:text-sm text-gray-600 mb-4"><%= truncate(character.description, length: 100) %></p>
 
           <!-- 詳細・削除ボタン -->
           <div class="flex justify-between">
             <%= link_to "詳細を見る", character_path(character), class: "btn btn-primary btn-sm" %>
-            <%= link_to "削除", character_path(character), method: :delete, class: "btn btn-error btn-sm" %>
-
+            <%= link_to "削除", character_path(character), method: :delete, data: { confirm: "本当に削除しますか？" }, class: "btn btn-error btn-sm" %>
           </div>
         </div>
       </div>

--- a/app/views/characters/new.html.erb
+++ b/app/views/characters/new.html.erb
@@ -2,18 +2,18 @@
   <h1 class="text-2xl font-bold text-center mb-6">キャラクター生成フォーム</h1>
 
   <%= form_with url: characters_path, method: :post, local: true, class: "space-y-4" do |f| %>
-    <!-- キャラクターの説明 -->
-    <div class="form-control">
-      <%= label_tag :description_from_user, "キャラクターの説明", class: "label font-bold" %>
-      <%= text_field_tag :description_from_user, nil, id: "description_from_user", 
-            class: "input input-bordered w-full", required: true, placeholder: "例: バイクに乗って銃を乱射する銃の達人" %>
-    </div>
-
     <!-- キャラクターのタイプ -->
     <div class="form-control">
       <%= label_tag :type, "キャラクターのタイプ", class: "label font-bold" %>
       <%= select_tag :type, options_for_select(["モンスター", "ヒーロー", "ロボット"]), 
             id: "type", class: "select select-bordered w-full", required: true %>
+    </div>
+
+    <!-- キャラクターの説明 -->
+    <div class="form-control">
+      <%= label_tag :description_from_user, "キャラクターの説明", class: "label font-bold" %>
+      <%= text_field_tag :description_from_user, nil, id: "description_from_user", 
+            class: "input input-bordered w-full", required: true, placeholder: "例: バイクに乗って銃を乱射する銃の達人" %>
     </div>
 
     <!-- 送信ボタン -->

--- a/app/views/characters/show.html.erb
+++ b/app/views/characters/show.html.erb
@@ -37,5 +37,6 @@
   <div class="mt-6 flex space-x-4">
     <button class="btn btn-primary">バトル開始！</button>
     <button class="btn btn-outline btn-secondary">共有</button>
+    <%= link_to "キャラー一覧", user_characters_path(current_user), class: "btn btn-outline btn-secondary" %>
   </div>
 </div>

--- a/app/views/tops/dashboard.html.erb
+++ b/app/views/tops/dashboard.html.erb
@@ -16,7 +16,7 @@
   </div>
   <div class="flex flex-col justify-between items-center p-4">
     <p class="mb-4">これまでに作ったキャラクターを選択し、バトルに挑もう！</p>
-    <button class="btn btn-primary w-full">キャラー一覧</button>
+    <%= link_to "キャラー一覧", user_characters_path(current_user), class: "btn btn-primary w-full" %>
   </div>
   <div class="flex flex-col justify-between items-center p-4">
     <p class="mb-4">これまでの戦闘結果を確認して、次の戦略を考えよう！</p>

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -11,6 +11,7 @@ CarrierWave.configure do |config|
     config.fog_public     = true
     config.fog_attributes = { 'Cache-Control' => "max-age=315576000" } # ACLを明示的に指定しない
     config.cache_storage  = :fog
+    config.remove_previously_stored_files_after_update = true
   else
     config.storage = :file
     config.root = Rails.root.join("public") # ローカル保存用のパス


### PR DESCRIPTION
画像生成モデルをDalle3からDalle2に変更しました。

画像生成時のプロンプトを調整しました。

キャラ削除機能を実装しました。

キャラ一覧ページを修正しました。
1. 文字サイズを変更
2. キャラ画像を詳細ページへのリンクになるように変更
3. キャラ画像がない場合にプレースホルダー画像を表示